### PR TITLE
refactor: #44 버튼 컴포넌트 리팩토링

### DIFF
--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -6,46 +6,48 @@ import {
   disabledStyles,
   radiusStyles,
   fontStyles,
-} from "./buttonStyles";
+} from "@/components/common/button/buttonStyles";
+import { twMerge } from "tailwind-merge";
+import clsx from "clsx";
 
 interface ButtonProps {
-  variant: "purple" | "white"; //버튼 스타일
-  disabled?: boolean; //비활성화 여부
+  variant: "purple" | "whiteViolet" | "whiteGray";
+  disabled?: boolean;
   width?: string;
   height?: string;
-  radius?: "sm" | "lg"; //둥글기 (4px 혹은 8px)
-  fontSize?: "xs" | "md" | "lg" | "2lg"; //12px, 14px, 16px, 18px
-  textColor?: "violet" | "gray"; //버튼 색이 white일 때만 사용
+  radius?: "sm" | "lg";
+  fontSize?: "xs" | "md" | "lg" | "2lg";
   onClick?: () => void;
   children: ReactNode;
 }
 
 const Button = ({
-  variant,
+  variant = "purple",
   disabled = false,
   width,
   height,
   radius = "lg",
   fontSize = "lg",
-  textColor = "violet",
   onClick,
   children,
+  ...props
 }: ButtonProps) => {
-  // 동적으로 클래스 조합
-  const buttonStyles = `${baseStyles} ${
-    disabled
-      ? disabledStyles
-      : variant === "purple"
-        ? variantStyles.purple
-        : variantStyles.white(textColor)
-  } ${radiusStyles[radius]} ${fontStyles[fontSize]}`;
+  const buttonStyles = twMerge(
+    clsx(
+      baseStyles,
+      disabled ? disabledStyles : variantStyles[variant],
+      radiusStyles[radius],
+      fontStyles[fontSize]
+    )
+  );
 
   return (
     <button
       className={buttonStyles}
       style={{ width, height }}
-      onClick={disabled ? undefined : onClick} // 비활성화 시 클릭 불가
+      onClick={disabled ? undefined : onClick}
       disabled={disabled}
+      {...props}
     >
       {children}
     </button>

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -5,29 +5,23 @@ import {
   variantStyles,
   disabledStyles,
   radiusStyles,
-  fontStyles,
 } from "@/components/common/button/buttonStyles";
 import { twMerge } from "tailwind-merge";
 import clsx from "clsx";
 
-interface ButtonProps {
+interface ButtonProps extends React.ComponentPropsWithoutRef<"button"> {
   variant: "purple" | "whiteViolet" | "whiteGray";
   disabled?: boolean;
-  width?: string;
-  height?: string;
   radius?: "sm" | "lg";
-  fontSize?: "xs" | "md" | "lg" | "2lg";
   onClick?: () => void;
   children: ReactNode;
 }
 
 const Button = ({
   variant = "purple",
+  className,
   disabled = false,
-  width,
-  height,
   radius = "lg",
-  fontSize = "lg",
   onClick,
   children,
   ...props
@@ -35,16 +29,15 @@ const Button = ({
   const buttonStyles = twMerge(
     clsx(
       baseStyles,
+      className,
       disabled ? disabledStyles : variantStyles[variant],
-      radiusStyles[radius],
-      fontStyles[fontSize]
+      radiusStyles[radius]
     )
   );
 
   return (
     <button
       className={buttonStyles}
-      style={{ width, height }}
       onClick={disabled ? undefined : onClick}
       disabled={disabled}
       {...props}

--- a/src/components/common/button/buttonStyles.tsx
+++ b/src/components/common/button/buttonStyles.tsx
@@ -13,10 +13,3 @@ export const radiusStyles = {
   sm: "rounded",
   lg: "rounded-lg",
 };
-
-export const fontStyles = {
-  xs: "text-xs leading-[18px]",
-  md: "text-md",
-  lg: "text-lg",
-  "2lg": "text-2lg",
-};

--- a/src/components/common/button/buttonStyles.tsx
+++ b/src/components/common/button/buttonStyles.tsx
@@ -1,13 +1,10 @@
 export const baseStyles =
   "box-border flex items-center justify-center px-4 font-medium transition-colors duration-100";
 
-// 기본 스타일 + variant별 스타일 + 비활성화 스타일
 export const variantStyles = {
   purple: "bg-violet text-white hover:bg-violet-700",
-  white: (textColor: "violet" | "gray") =>
-    `bg-white border border-gray-400 ${
-      textColor === "violet" ? "text-violet" : "text-gray-600"
-    } hover:bg-purple-50`,
+  whiteViolet: "bg-white border border-gray-400 text-violet hover:bg-purple-50",
+  whiteGray: "bg-white border border-gray-400 text-gray-600 hover:bg-purple-50",
 };
 
 export const disabledStyles = "bg-gray-500 text-white cursor-not-allowed";
@@ -18,8 +15,8 @@ export const radiusStyles = {
 };
 
 export const fontStyles = {
-  xs: "text-xs leading-[18px]", // 12px / 18px
-  md: "text-md", // 14px / 24px
-  lg: "text-lg", // 16px / 26px
-  "2lg": "text-2lg", // 18px / 26px
+  xs: "text-xs leading-[18px]",
+  md: "text-md",
+  lg: "text-lg",
+  "2lg": "text-2lg",
 };


### PR DESCRIPTION
## #️⃣ Issue Number
#44

<br/>

## 📝 요약
- 버튼 컴포넌트 리팩토링 스타일 관리 개선
- 필요없는 주석 제거
- `textColor` prop 제거하고 `variant`에 `whiteViolet`(하얀 배경 버튼에 font color는 보라색), `whiteGray` (하얀배경 버튼에 font color는 회색)추가.
- `clsx`와 `twMerge`로 스타일 조합 최적화
- `rest props`에 `ComponentPropsWithoutRef<"button">` 타입 지정으로 HTML 속성 유연성 확보
- 반응형 위해 `fontSize`, `width`, `height` 제거하고 `className`으로 대체 (현지님 피드백 수용)

<br/>

## 🛠️ PR 유형

<!--- 해당하는 변경 사항에 체크하세요. -->

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>

## 📢 공유 사항
- **주요 props 변화**:
  - `variant`: `purple` (보라색 배경), `whiteViolet` (흰 배경, 보라 글자), `whiteGray` (흰 배경, 회색 글자).
  - width, height, fontSize 제거, className으로 대체
  ```tsx
    <Button variant="whiteGray" className="w-[520px] h-[50px] text-2lg tablet:w-[256px]">로그인</Button>
  ```

## 😖고민중인 내용
![image](https://github.com/user-attachments/assets/c5f9a633-8bcf-4521-99b3-61cf224601fb)
- 현재 rest props에 타입을 지정하지 않아도 빈객체로 타입이 지정되어 동작엔 문제가 없지만 타입을 명확히 지정해볼까 합니다. 
- 구글링도 해보고 gpt도 돌려본 결과 2가지로 추려지는데 둘 중 어떤것을 사용해야할지 고민됩니다.🥲 도와주세요

---
## 요약
`React.ButtonHTMLAttributes<HTMLButtonElement>` 활용
`ButtonHTMLAttributes`는 <button> 요소에 특화된 타입을 제공하며, 그 내부에는 onClick, disabled, type과 같은 버튼의 기본적인 속성들이 모두 정의되어 있다. 이 타입을 사용하는 방식은 간단하고 직관적이며, 대부분의 경우 유효하고 잘 작동한다.

```ts
interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
  variant?: "primary" | "secondary" | "disable";
  size?: "md" | "lg";
  children: React.ReactNode;
}
```
이렇게 하면 Button 컴포넌트에서 버튼의 기본적인 속성뿐만 아니라 onClick, type과 같은 HTML 속성들도 모두 타입으로 안전하게 받을 수 있다. 이 방식이 가장 일반적이고, 특정 button 요소에만 필요한 속성을 모두 처리할 수 있기 때문에 일반적인 사용에 있어 문제 없이 잘 작동한다.

문제점
- `ButtonHTMLAttributes<T>`에서의 `T`는 HTML 요소에 대한 제네릭 타입 매개변수로, button에 대한 타입을 넣어주는 것이 맞다.
- ButtonHTMLAttributes 내부의 이벤트 핸들러들은 DOMAttributes<T>에서 가져온 이벤트 타입들을 사용하기 때문에, T가 HTMLButtonElement로 설정되면 버튼 이벤트들에 대한 타입을 자동으로 처리해준다.

대안 
 `React.ComponentProps<"button">` 방법은 더 일반적인 접근법으로, 버튼 외에도 다양한 HTML 요소나 컴포넌트의 타입을 쉽게 다룰 수 있는 방법이다.

```ts
interface ButtonProps extends React.ComponentProps<"button"> {
  variant?: "primary" | "secondary" | "disable";
  size?: "md" | "lg";
  children: React.ReactNode;
}
```
이 방법을 사용하면 button에 특화된 속성뿐만 아니라, 모든 HTML 버튼 속성을 쉽게 처리할 수 있다. 특히, 타입을 일일이 다 나열할 필요 없이 모든 button 속성을 포함시킬 수 있다는 장점이 있다.

```ts
<Button onClick={handleClick} id="myButton" type="submit" aria-label="Submit Button">
  Submit
</Button>
```
이 예시처럼, `id`, `aria-label`, `type` 같은 HTML 표준 속성들이 `ComponentProps<"button">`을 통해 자동으로 처리되며, 추가적으로 variant나 size와 같은 커스텀 속성도 타입으로 안전하게 처리된다.

`ButtonHTMLAttributes` vs `ComponentProps`
`React.ButtonHTMLAttributes<HTMLButtonElement>`는 button 요소에 특화된 타입을 제공하며, 버튼에 필요한 필수적인 속성들(onClick, disabled, type)을 다룰 때 유용하다. 기본적인 버튼 속성들에 대해서는 이 타입이 간단하고 안전한 방법이다.

`React.ComponentProps<"button">`는 더 일반화된 방법으로, HTML button 요소뿐만 아니라 다양한 HTML 요소의 속성들까지 포함하고 있다. 또한 컴포넌트의 props 타입을 쉽게 확장할 수 있는 유용한 방법이기도 하다. 이 방법은 button에 한정되지 않으며, 다양한 HTML 요소나 커스텀 컴포넌트에 대해 전반적으로 타입을 확장할 수 있다는 점에서 더 유연하다.

<br/>

## 📚 참고 자료
['DetailedHTMLProps<ButtonHTMLAttributes, HTMLButtonElement>'](https://velog.io/@qhflrnfl4324/DetailedHTMLPropsButtonHTMLAttributes-HTMLButtonElement-%ED%98%95%EC%8B%9D%EC%97%90-css-%EC%86%8D%EC%84%B1%EC%9D%B4-%EC%97%86%EC%8A%B5%EB%8B%88%EB%8B%A4.-Emotion-with-TypeScript#%EA%B3%B5%EC%9A%A9-button-%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8-%EB%A7%8C%EB%93%A4%EA%B8%B0)
[ComponentProps 사용기](https://velog.io/@kmh060020/%EC%9C%A0%EC%9A%A9%ED%95%9C-ComponentProps-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0)
[컴포넌트를 만들 때 기존 태그의 props를 상속받는 법
](https://yogjin.tistory.com/61#ComponentPropsWithoutRef-1)
