### PR TITLE
refactor: #46/로고 버튼 네비게이팅 기능 변경

### DIFF
--- a/src/components/common/logo-button/LogoButton.tsx
+++ b/src/components/common/logo-button/LogoButton.tsx
@@ -1,4 +1,5 @@
-import Link from "next/link";
+import { useDashboardStore } from "@/lib/hooks/useDashboardStore";
+import { useRouter } from "next/navigation";
 import Image from "next/image";
 import SmallLogo from "../../../../public/logo/logo_small.svg";
 import LargeLogo from "../../../../public/logo/logo_large.svg";
@@ -10,10 +11,26 @@ export default function LogoButton({
   variant: "white" | "purple";
   isMobile: boolean;
 }) {
+  const router = useRouter();
+
+  const setDashboardId = useDashboardStore((state) => state.setDashboardId);
+
+  const navigateToHome = () => {
+    router.push("/");
+  };
+
+  const navigateToMyDashboard = () => {
+    router.push("/mydashboard");
+    setDashboardId(null);
+  };
+
   const isHome = variant === "white";
 
   return (
-    <Link href={isHome ? "/" : "/mydashboard"}>
+    <button
+      type="button"
+      onClick={isHome ? navigateToHome : navigateToMyDashboard}
+    >
       <Image
         src={isMobile ? SmallLogo : LargeLogo}
         width={isMobile ? 24 : 110}
@@ -21,6 +38,6 @@ export default function LogoButton({
         className={isHome ? "invert brightness-0" : ""}
         alt=""
       />
-    </Link>
+    </button>
   );
 }

--- a/src/components/common/logo-button/LogoButton.tsx
+++ b/src/components/common/logo-button/LogoButton.tsx
@@ -4,26 +4,23 @@ import SmallLogo from "../../../../public/logo/logo_small.svg";
 import LargeLogo from "../../../../public/logo/logo_large.svg";
 
 export default function LogoButton({
-  isMobile,
   variant,
+  isMobile,
 }: {
+  variant: "white" | "purple";
   isMobile: boolean;
-  variant: "purple" | "white";
 }) {
+  const isHome = variant === "white";
+
   return (
-    <button
-      type="button"
-      className="flex justify-center items-center pc:justify-start"
-    >
-      <Link href="/">
-        <Image
-          src={isMobile ? SmallLogo : LargeLogo}
-          width={isMobile ? 24 : 110}
-          height={isMobile ? 30 : 34}
-          className={variant === "white" ? "invert brightness-0" : ""}
-          alt=""
-        />
-      </Link>
-    </button>
+    <Link href={isHome ? "/" : "/mydashboard"}>
+      <Image
+        src={isMobile ? SmallLogo : LargeLogo}
+        width={isMobile ? 24 : 110}
+        height={isMobile ? 30 : 34}
+        className={isHome ? "invert brightness-0" : ""}
+        alt=""
+      />
+    </Link>
   );
 }

--- a/src/components/layout/sidebar/Sidebar.tsx
+++ b/src/components/layout/sidebar/Sidebar.tsx
@@ -11,8 +11,10 @@ export default function Sidebar() {
   const isMobile = width < BREAKPOINTS.TABLET;
 
   return (
-    <div className="flex flex-col gap-10 tablet:gap-[57px] pc:gap-14">
-      <LogoButton isMobile={isMobile} variant={"purple"} />
+    <div className="flex flex-col gap-[39px] tablet:gap-[57px] pc:gap-14">
+      <div className="flex justify-center items-center tablet:justify-start">
+        <LogoButton variant={"purple"} isMobile={isMobile} />
+      </div>
       <div className="flex flex-col items-center gap-[22px] tablet:gap-[15px] tablet:items-stretch pc:gap-[16px]">
         <div className="flex justify-between">
           {!isMobile && (

--- a/src/lib/hooks/useDashboardStore.ts
+++ b/src/lib/hooks/useDashboardStore.ts
@@ -3,7 +3,7 @@ import { create } from "zustand";
 
 type DashboardState = {
   dashboardId: string | null;
-  setDashboardId: (id: string) => void;
+  setDashboardId: (id: string | null) => void;
 };
 
 export const useDashboardStore = create<DashboardState>((set) => ({

--- a/src/lib/utils/colorUtils.ts
+++ b/src/lib/utils/colorUtils.ts
@@ -1,19 +1,19 @@
-export function getColorName(hex: string): string {
-  switch (hex) {
-    case "#7AC555":
-      return "green";
+export function getHEXCode(color: string): string {
+  switch (color) {
+    case "green":
+      return "#7AC555";
       break;
-    case "#760DDE":
-      return "purple";
+    case "purple":
+      return "#760DDE";
       break;
-    case "#FFA500":
-      return "orange";
+    case "orange":
+      return "#FFA500";
       break;
-    case "#76A6EA":
-      return "blue";
+    case "blue":
+      return "#76A6EA";
       break;
-    case "#E876EA":
-      return "pink";
+    case "pink":
+      return "#E876EA";
       break;
     default:
       return "";


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- "#이슈번호" 형식으로 입력해주세요. -->
#46 

<br/>

## 📝 요약

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
<!--- "어떻게"보다 "무엇"을 "왜" 수정했는지 설명하는 것이 좋습니다. -->

- **`variant`가 `white`인 경우에는 `/`로 이동하고, `purple`인 경우에는 `/mydashboard`로 이동한다.**
   - 랜딩페이지에서만 흰색 로고가 사용되고, 나머지 페이지에서는 모두 보라색 로고가 사용된다.
   - 랜딩페이지에서 로고 버튼을 누르면 `/`로 이동하고, 나머지 페이지에서 로고 버튼을 누르면 `/mydashboard`로 이동한다.
- **로고 버튼 클릭 시 `dashboardid` 값을 `null`로 변경한다.**
   - 그렇지 않으면 특정 대시보드 페이지에서 로고 버튼 클릭 시, `/mydashboard` 페이지로 이동한 후에도 사이드 바에 해당 대시보드가 표시된다.(대시보드 버튼의 배경색이 `violet-8`)

<br/>

## 🛠️ PR 유형

<!--- 해당하는 변경 사항에 체크하세요. -->

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>

## 📷 스크린샷

<!--- 없을 시 해당 목차는 삭제해주세요. -->

https://github.com/user-attachments/assets/64b2d90f-5e1f-46ba-823e-c3d6a5f0849b

<br/>