### PR TITLE
버튼 컴포넌트 사이즈 prop 추가

### DIFF
--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -5,6 +5,7 @@ import {
   variantStyles,
   disabledStyles,
   radiusStyles,
+  sizeStyles,
 } from "@/components/common/button/buttonStyles";
 import { twMerge } from "tailwind-merge";
 import clsx from "clsx";
@@ -13,6 +14,7 @@ interface ButtonProps extends React.ComponentPropsWithoutRef<"button"> {
   variant: "purple" | "whiteViolet" | "whiteGray";
   disabled?: boolean;
   radius?: "sm" | "lg";
+  size?: "sm" | "md" | "lg";
   onClick?: () => void;
   children: ReactNode;
 }
@@ -22,6 +24,7 @@ const Button = ({
   className,
   disabled = false,
   radius = "lg",
+  size = "md",
   onClick,
   children,
   ...props
@@ -31,7 +34,8 @@ const Button = ({
       baseStyles,
       className,
       disabled ? disabledStyles : variantStyles[variant],
-      radiusStyles[radius]
+      radiusStyles[radius],
+      sizeStyles[size]
     )
   );
 

--- a/src/components/common/button/buttonStyles.tsx
+++ b/src/components/common/button/buttonStyles.tsx
@@ -13,3 +13,9 @@ export const radiusStyles = {
   sm: "rounded",
   lg: "rounded-lg",
 };
+
+export const sizeStyles = {
+  sm: "h-9",
+  md: "h-11",
+  lg: "h-13",
+};


### PR DESCRIPTION
## #️⃣ Issue Number
#73
<!--- "#이슈번호" 형식으로 입력해주세요. -->

<br/>

## 📝 요약

- buttonStyles.ts에 sizeStyles 도입: 버튼의 크기를 정의하는 sizeStyles를 추가
```
sm: 36px
md: 44px
lg: 52px
```
- ButtonProps에 size prop 추가: 버튼의 속성(ButtonProps)에 size 속성을 추가, 속성의 선택지는 `sm`, `md`, `lg`
- 버튼 컴포넌트의 기본 크기를 md로 설정, 특별히 다른 크기를 지정하지 않는 경우 44px로 표시

<br/>

## 🛠️ PR 유형

<!--- 해당하는 변경 사항에 체크하세요. -->

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>

## 📷 스크린샷

<!--- 없을 시 해당 목차는 삭제해주세요. -->

<br/>

## 📢 공유 사항

```
      <Button variant="purple" size="sm">Small</Button>
      <Button variant="whiteViolet" size="md">Medium</Button>
      <Button variant="whiteGray" size="lg">Large</Button>
```
