### PR TITLE
feat: #88/대시보드 상세 페이지 할 일 카드 무한 스크롤

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,7 @@ const nextConfig = {
     //로컬 이미지 테스트 하기 위해 localhost를 넣었습니다.
     domains: ["sprint-fe-project.s3.ap-northeast-2.amazonaws.com", "localhost"],
   },
+  reactStrictMode: false,
 };
 
 export default nextConfig;

--- a/src/app/(after-login)/dashboard/[dashboardid]/_components/AddTaskButton.tsx
+++ b/src/app/(after-login)/dashboard/[dashboardid]/_components/AddTaskButton.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useModalStore } from "@/lib/store/useModalStore";
 import Button from "@/components/common/button/Button";
 import Image from "next/image";

--- a/src/app/(after-login)/dashboard/[dashboardid]/_components/EditColumnButton.tsx
+++ b/src/app/(after-login)/dashboard/[dashboardid]/_components/EditColumnButton.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useModalStore } from "@/lib/store/useModalStore";
 import { useColumnStore } from "@/lib/store/useColumnStore";
 import Image from "next/image";

--- a/src/lib/apis/cardsApi.ts
+++ b/src/lib/apis/cardsApi.ts
@@ -2,12 +2,21 @@ import { BASE_URL } from "@/lib/constants/urls";
 
 export async function fetchTaskCardList({
   token,
-  id,
+  size,
+  cursorId,
+  columnId,
 }: {
   token: string;
-  id: number;
+  size: number;
+  cursorId: number | null;
+  columnId: number;
 }) {
-  const res = await fetch(`${BASE_URL}/cards?size=10&columnId=${id}`, {
+  let query = `size=${size}&columnId=${columnId}`;
+  if (cursorId !== null) {
+    query += `&cursorId=${cursorId}`;
+  }
+
+  const res = await fetch(`${BASE_URL}/cards?${query}`, {
     headers: {
       Accept: "application/json",
       Authorization: `Bearer ${token}`,


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- "#이슈번호" 형식으로 입력해주세요. -->
#88 

<br/>

## 📝 요약

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
<!--- "어떻게"보다 "무엇"을 "왜" 수정했는지 설명하는 것이 좋습니다. -->
- Column 컴포넌트에서 IntersectionObserver를 활용하여 TaskCard 리스트를 무한 스크롤 방식으로 불러오도록 구현

<br/>

## 🛠️ PR 유형

<!--- 해당하는 변경 사항에 체크하세요. -->

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>


## 📚 참고 자료

<!--- 코드 이해에 도움이 되는 자료 및 설명을 추가해주세요. -->
### 무한 스크롤 흐름
1. 마운트
2. `handleLoad` 함수를 호출하여 첫 페이지 카드들 불러옴
3. 마지막 카드 요소에 `ref` 연결
4. `ref` 요소, 즉 마지막 카드가 화면에 보이면 `IntersectionObserver` 감지
5. `handleLoad` 함수를 다시 호출하여 다음 페이지 카드들 불러옴
6. 더 이상 받아올 데이터가 없으면 `isLast`가 `true`가 되고 데이터 불러오기 완료

### `isLoading`과 `isLast` state의 필요성
**`isLoading`**
데이터 요청 중 중복 호출 방지
**`isLast`**
마지막 페이지 여부를 확인하여 무한 요청 방지

### `handleLoad` 함수
- 중복 요청과 마지막 페이지 요청을 방지한다.
  ```
  if (isLoading || isLast) return;
  ```
- 받아온 카드를 누적으로 저장한다.
  ```
  setItems(prev => [...prev, ...newCards]);
  ```
- 마지막 페이지를 판단하여 `isLast` 값을 갱신한다.(페이지 사이즈보다 데이터의 길이가 작거나 `nextCursorId`가 null이면 마지막 페이지라는 의미)
  ```
   if (newCards.length < PAGE_SIZE || nextCursorId === null) {
     setIsLast(true);
   }
   ```
### 마지막 카드에만 `ref` 걸기
```
{items.map((item, index) => (
  <div
    key={item.id}
    ref={index === items.length - 1 ? observerRef : null}
  >
    <TaskCard {...item} columnTitle={title} />
  </div>
))}
```
- `TaskCard` 리스트 중 마지막 TaskCard div에만 `ref`를 달아준다.
- 그럼 해당 `ref`를 통해 `IntersectionObserver`가 마지막 카드가 보이는 것을 감지한다.

### `IntersectionObserver` 등록
- 마지막 페이지면 observer 등록을 하지 않는다.
  ```
  if (isLast) return;
  ```
- `IntersectionObserver`는 DOM 요소가 뷰포트에 들어오는 것을 감지한다.
  - 관찰 중인 요소(`entries[0]`이 뷰포트에 보이면 `handleLoad` 함수 실행
    ```
    if (entries[0].isIntersecting) {
          handleLoad();
        }
     ```
- `observerRef.current`(`ref`로 연결된 DOM 요소, 즉 마지막 `TaskCard` div)를 감시하기 위해 `observer`에 연결
  ```
  const current = observerRef.current;
  if (current) observer.observe(current);
  ```
- 리스트가 새로 업데이트되면 `ref`가 다른 요소에 재할당되는데, 이전 `ref`에 연결된 `observer`를 끊지 않으면 여러 요소가 동시에 감시되기 때문에, 현재 감시 중인 요소(`current`, 즉 마지막 `TaskCard` div)를 그만 감시하도록 해준다.
  ```
  if (current) observer.unobserve(current);
   ```
- 모든 관찰 중인 요소를 제거하고 해당 `observer` 인스턴스를 메모리에서 정리해준다.
   ```
   observer.disconnect();
   ```