### PR TITLE
feat: #22/사이드 바 페이지네이션 구현

### DIFF
--- a/src/app/(after-login)/dashboard/[dashboardid]/_components/Column.tsx
+++ b/src/app/(after-login)/dashboard/[dashboardid]/_components/Column.tsx
@@ -7,6 +7,7 @@ import { TOKEN_1 } from "@/lib/constants/tokens";
 import EditColumnButton from "./EditColumnButton";
 import AddTaskButton from "./AddTaskButton";
 import TaskCard from "./TaskCard";
+import { useIntersection } from "@/lib/hooks/useIntersection";
 
 const PAGE_SIZE = 3;
 
@@ -50,26 +51,11 @@ export default function Column({ id, title }: DashboardColumn) {
     handleLoad();
   }, []);
 
-  useEffect(() => {
-    if (isLast) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting) {
-          handleLoad();
-        }
-      },
-      { threshold: 0.5 }
-    );
-
-    const current = observerRef.current;
-    if (current) observer.observe(current);
-
-    return () => {
-      if (current) observer.unobserve(current);
-      observer.disconnect();
-    };
-  }, [cursorId, isLoading, isLast]);
+  useIntersection({
+    target: observerRef,
+    onIntersect: handleLoad,
+    disabled: isLast,
+  });
 
   return (
     <div className="h-full py-4 border-b border-gray-300 tablet:px-5 tablet:pt-[22px] tablet:pb-5 pc:border-b-0 pc:border-r">

--- a/src/app/(after-login)/dashboard/[dashboardid]/_components/Column.tsx
+++ b/src/app/(after-login)/dashboard/[dashboardid]/_components/Column.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { useEffect, useState, useRef } from "react";
+import { useIntersection } from "@/lib/hooks/useIntersection";
 import { DashboardColumn, TaskCardList } from "@/lib/types";
 import { fetchTaskCardList } from "@/lib/apis/cardsApi";
 import { TOKEN_1 } from "@/lib/constants/tokens";
 import EditColumnButton from "./EditColumnButton";
 import AddTaskButton from "./AddTaskButton";
 import TaskCard from "./TaskCard";
-import { useIntersection } from "@/lib/hooks/useIntersection";
 
 const PAGE_SIZE = 3;
 

--- a/src/app/(after-login)/mydashboard/layout.tsx
+++ b/src/app/(after-login)/mydashboard/layout.tsx
@@ -4,13 +4,18 @@ import { TOKEN_1 } from "@/lib/constants/tokens";
 import DashboardMenu from "@/components/layout/navbar/DashboardMenu";
 import UserMenu from "@/components/layout/navbar/UserMenu";
 
+const PAGE_SIZE = 15;
+
 export default async function Layout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  // 가장 첫 번째 페이지 리스트 불러오도록 나중에 수정
-  const { dashboards } = await fetchDashboardList(TOKEN_1);
+  const { dashboards } = await fetchDashboardList({
+    token: TOKEN_1,
+    page: 1,
+    size: PAGE_SIZE,
+  });
 
   const firstDashboardId = dashboards[0]?.id;
 

--- a/src/app/(after-login)/mypage/layout.tsx
+++ b/src/app/(after-login)/mypage/layout.tsx
@@ -4,13 +4,18 @@ import { TOKEN_1 } from "@/lib/constants/tokens";
 import DashboardMenu from "@/components/layout/navbar/DashboardMenu";
 import UserMenu from "@/components/layout/navbar/UserMenu";
 
+const PAGE_SIZE = 15;
+
 export default async function Layout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  // 가장 첫 번째 페이지 리스트 불러오도록 나중에 수정
-  const { dashboards } = await fetchDashboardList(TOKEN_1);
+  const { dashboards } = await fetchDashboardList({
+    token: TOKEN_1,
+    page: 1,
+    size: PAGE_SIZE,
+  });
 
   const firstDashboardId = dashboards[0]?.id;
 

--- a/src/components/layout/sidebar/SideMenuItem.tsx
+++ b/src/components/layout/sidebar/SideMenuItem.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useIsMobile } from "@/lib/hooks/useCheckViewport";
 import { useDashboardStore } from "@/lib/store/useDashboardStore";
 import { useRouter } from "next/navigation";
@@ -26,7 +24,7 @@ export default function SideMenuItem({
       onClick={() => {
         router.push(`/dashboard/${id}`);
       }}
-      className="flex items-center p-4 rounded hover:bg-violet-8 tablet:px-[10px] tablet:py-2 pc:p-3"
+      className="flex items-center w-full p-4 rounded hover:bg-violet-8 tablet:px-[10px] tablet:py-2 pc:p-3"
       style={isCurrent ? { background: "#f1effd" } : {}}
       disabled={isCurrent}
     >

--- a/src/components/layout/sidebar/SideMenuList.tsx
+++ b/src/components/layout/sidebar/SideMenuList.tsx
@@ -1,21 +1,63 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import { useIntersection } from "@/lib/hooks/useIntersection";
 import { DashboardList } from "@/lib/types";
 import { fetchDashboardList } from "@/lib/apis/dashboardsApi";
 import { TOKEN_1 } from "@/lib/constants/tokens";
 import SideMenuItem from "./SideMenuItem";
 
-export default async function SideMenuList() {
-  const { dashboards, totalCount, cursorId } =
-    await fetchDashboardList(TOKEN_1);
-  const items: DashboardList[] = dashboards;
+const PAGE_SIZE = 15;
 
-  // 해당 값들 사용하게 되면 지울 테스트 코드들
-  console.log(totalCount);
-  console.log(cursorId);
+export default function SideMenuList() {
+  const [items, setItems] = useState<DashboardList[]>([]);
+  const [page, setPage] = useState(1);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLast, setIsLast] = useState(false);
+  const observerRef = useRef<HTMLDivElement | null>(null);
+
+  const handleLoad = async () => {
+    if (isLoading || isLast) return;
+    setIsLoading(true);
+
+    try {
+      const { dashboards: newDashboards, cursorId: nextCursorId } =
+        await fetchDashboardList({
+          token: TOKEN_1,
+          size: PAGE_SIZE,
+          page,
+        });
+
+      if (newDashboards.length === 0) {
+        setIsLast(true);
+      } else {
+        setItems((prev) => [...prev, ...newDashboards]);
+        setPage((prev) => prev + 1);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    handleLoad();
+  }, []);
+
+  useIntersection({
+    target: observerRef,
+    onIntersect: handleLoad,
+    disabled: isLast,
+  });
 
   return (
-    <div className="flex flex-col gap-[14px] tablet:gap-[2px] pc:gap-2">
-      {items.map((item) => (
-        <SideMenuItem key={item.id} {...item} />
+    <div className="flex flex-col gap-[14px] flex-grow min-h-0 overflow-y-auto whitespace-nowrap scrollbar-hide tablet:gap-[2px] pc:gap-2">
+      {items.map((item, index) => (
+        <div
+          key={item.id}
+          ref={index === items.length - 1 ? observerRef : null}
+        >
+          <SideMenuItem {...item} />
+        </div>
       ))}
     </div>
   );

--- a/src/components/layout/sidebar/SideMenuList.tsx
+++ b/src/components/layout/sidebar/SideMenuList.tsx
@@ -21,12 +21,11 @@ export default function SideMenuList() {
     setIsLoading(true);
 
     try {
-      const { dashboards: newDashboards, cursorId: nextCursorId } =
-        await fetchDashboardList({
-          token: TOKEN_1,
-          size: PAGE_SIZE,
-          page,
-        });
+      const { dashboards: newDashboards } = await fetchDashboardList({
+        token: TOKEN_1,
+        size: PAGE_SIZE,
+        page,
+      });
 
       if (newDashboards.length === 0) {
         setIsLast(true);

--- a/src/components/layout/sidebar/index.tsx
+++ b/src/components/layout/sidebar/index.tsx
@@ -5,11 +5,11 @@ import SideMenuList from "./SideMenuList";
 
 export default function Sidebar() {
   return (
-    <div className="flex flex-col gap-[39px] tablet:gap-[57px] pc:gap-14">
+    <div className="flex flex-col gap-[39px] h-full tablet:gap-[57px] pc:gap-14">
       <div className="flex justify-center items-center tablet:justify-start">
         <LogoButton variant={"purple"} />
       </div>
-      <div className="flex flex-col items-center gap-[22px] tablet:gap-[15px] tablet:items-stretch pc:gap-[16px]">
+      <div className="flex flex-col items-center gap-[22px] flex-grow min-h-0 tablet:gap-[15px] tablet:items-stretch pc:gap-[16px]">
         <div className="flex justify-between">
           <SideMenuHeader />
           <AddButton />

--- a/src/lib/apis/dashboardsApi.ts
+++ b/src/lib/apis/dashboardsApi.ts
@@ -1,8 +1,16 @@
 import { BASE_URL } from "@/lib/constants/urls";
 
-export async function fetchDashboardList(token: string) {
+export async function fetchDashboardList({
+  token,
+  page,
+  size,
+}: {
+  token: string;
+  page: number;
+  size: number;
+}) {
   const res = await fetch(
-    `${BASE_URL}/dashboards?navigationMethod=pagination&page=1&size=10`,
+    `${BASE_URL}/dashboards?navigationMethod=pagination&page=${page}&size=${size}`,
     {
       headers: {
         Accept: "application/json",

--- a/src/lib/hooks/useIntersection.ts
+++ b/src/lib/hooks/useIntersection.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface UseIntersectionProps {
+  target: React.RefObject<Element>;
+  onIntersect: () => void;
+  disabled?: boolean;
+  threshold?: number;
+}
+
+export function useIntersection({
+  target,
+  onIntersect,
+  disabled,
+  threshold = 0.5,
+}: UseIntersectionProps) {
+  useEffect(() => {
+    if (disabled) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          onIntersect();
+        }
+      },
+      { threshold: threshold }
+    );
+
+    const current = target.current;
+    if (current) observer.observe(current);
+
+    return () => {
+      if (current) observer.unobserve(current);
+      observer.disconnect();
+    };
+  }, [target, onIntersect, disabled]);
+}


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- "#이슈번호" 형식으로 입력해주세요. -->
#22 

<br/>

## 📝 요약

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
<!--- "어떻게"보다 "무엇"을 "왜" 수정했는지 설명하는 것이 좋습니다. -->
- useIntersection 훅을 만들어서 무한 스크롤을 구현할 때 가져다 사용할 수 있게 했습니다.
- 사이드 바는 페이지네이션 리퀘스트로 요청을 보내되, 버튼식으로 페이지가 넘어가지 않고 무한 스크롤로 목록을 넘길 수 있도록 했습니다.

<br/>

## 🛠️ PR 유형

<!--- 해당하는 변경 사항에 체크하세요. -->

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>


## 📢 공유 사항

<!--- 차후 작업 시 알아야 할 내용이 있다면 작성해주세요. -->
#### `useIntersection` hook 사용 방법
```
  useIntersection({
    target: observerRef,
    onIntersect: handleLoad,
    disabled: isLast,
  });
```
- **target**: 관찰할 DOM 요소 (마지막 아이템의 ref)
- **onIntersect**: 요소가 화면에 보일 때 실행할 콜백 함수
- **disabled**: `true`이면 observer 비활성화 (더 이상 데이터 없음 = `isLast`)
