### PR TITLE
feat: #67/네비게이션 바 유저 메뉴 로그아웃 api 연결 & 로그인/로그아웃 시 리디렉트 & 실제 액세스 토큰으로 리퀘스트

### DIFF
--- a/src/app/(after-login)/dashboard/[dashboardid]/_components/Column.tsx
+++ b/src/app/(after-login)/dashboard/[dashboardid]/_components/Column.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState, useRef } from "react";
 import { useIntersection } from "@/lib/hooks/useIntersection";
 import { DashboardColumn, TaskCardList } from "@/lib/types";
 import { fetchTaskCardList } from "@/lib/apis/cardsApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
 import EditColumnButton from "./EditColumnButton";
 import AddTaskButton from "./AddTaskButton";
 import TaskCard from "./TaskCard";
@@ -18,6 +17,7 @@ export default function Column({ id, title }: DashboardColumn) {
   const [isLoading, setIsLoading] = useState(false);
   const [isLast, setIsLast] = useState(false);
   const observerRef = useRef<HTMLDivElement | null>(null);
+  const accessToken = localStorage.getItem("accessToken") ?? "";
 
   const handleLoad = async () => {
     if (isLoading || isLast) return;
@@ -29,7 +29,7 @@ export default function Column({ id, title }: DashboardColumn) {
         cursorId: nextCursorId,
         totalCount,
       } = await fetchTaskCardList({
-        token: TOKEN_1,
+        token: accessToken,
         size: PAGE_SIZE,
         cursorId,
         columnId: id,

--- a/src/app/(after-login)/dashboard/[dashboardid]/layout.tsx
+++ b/src/app/(after-login)/dashboard/[dashboardid]/layout.tsx
@@ -26,6 +26,8 @@ export default async function Layout({
 
   const memberData = await fetchDashboardMember({
     token: accessToken,
+    page: 1,
+    size: null,
     id: params.dashboardid,
   });
 

--- a/src/app/(after-login)/dashboard/[dashboardid]/layout.tsx
+++ b/src/app/(after-login)/dashboard/[dashboardid]/layout.tsx
@@ -2,7 +2,7 @@ import DashboardIdSetter from "./_components/DashboardIdSetter";
 import { DashboardDetail } from "@/lib/types";
 import { fetchDashboard } from "@/lib/apis/dashboardsApi";
 import { fetchDashboardMember } from "@/lib/apis/membersApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
+import { cookies } from "next/headers";
 import DashboardMenu from "@/components/layout/navbar/DashboardMenu";
 import MemberList from "@/components/layout/navbar/MemberList";
 import UserMenu from "@/components/layout/navbar/UserMenu";
@@ -15,17 +15,17 @@ export default async function Layout({
   children: React.ReactNode;
   params?: { dashboardid?: string };
 }) {
-  if (!params?.dashboardid) {
-    return;
-  }
+  const accessToken = cookies().get("accessToken")?.value ?? "";
+
+  if (!params?.dashboardid) return;
 
   const dashboardData: DashboardDetail = await fetchDashboard({
-    token: TOKEN_1,
+    token: accessToken,
     id: params.dashboardid,
   });
 
   const memberData = await fetchDashboardMember({
-    token: TOKEN_1,
+    token: accessToken,
     id: params.dashboardid,
   });
 

--- a/src/app/(after-login)/dashboard/[dashboardid]/page.tsx
+++ b/src/app/(after-login)/dashboard/[dashboardid]/page.tsx
@@ -10,11 +10,7 @@ export default async function Page({
 }: {
   params: { dashboardid: string };
 }) {
-  const accessToken = cookies().get("accessToken")?.value;
-
-  if (!accessToken) {
-    redirect("/");
-  }
+  const accessToken = cookies().get("accessToken")?.value ?? "";
 
   const { data } = await fetchColumnList({
     token: accessToken,

--- a/src/app/(after-login)/dashboard/[dashboardid]/page.tsx
+++ b/src/app/(after-login)/dashboard/[dashboardid]/page.tsx
@@ -1,7 +1,6 @@
 import { DashboardColumn } from "@/lib/types";
 import { fetchColumnList } from "@/lib/apis/columnsApi";
 import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import Column from "./_components/Column";
 import AddColumnButton from "./_components/AddColumnButton";
 

--- a/src/app/(after-login)/dashboard/[dashboardid]/page.tsx
+++ b/src/app/(after-login)/dashboard/[dashboardid]/page.tsx
@@ -1,6 +1,7 @@
 import { DashboardColumn } from "@/lib/types";
 import { fetchColumnList } from "@/lib/apis/columnsApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 import Column from "./_components/Column";
 import AddColumnButton from "./_components/AddColumnButton";
 
@@ -9,8 +10,14 @@ export default async function Page({
 }: {
   params: { dashboardid: string };
 }) {
+  const accessToken = cookies().get("accessToken")?.value;
+
+  if (!accessToken) {
+    redirect("/");
+  }
+
   const { data } = await fetchColumnList({
-    token: TOKEN_1,
+    token: accessToken,
     id: params.dashboardid,
   });
   const items: DashboardColumn[] = data;

--- a/src/app/(after-login)/layout.tsx
+++ b/src/app/(after-login)/layout.tsx
@@ -1,10 +1,18 @@
 import { ReactNode } from "react";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import ROUTE from "@/lib/constants/route";
 import Sidebar from "@/components/layout/sidebar";
-
 import ModalProvider from "@/components/common/modal/ModalProvider";
 import AlertProvider from "@/components/common/alert/AlertProvider";
 
 export default function Layout({ children }: { children: ReactNode }) {
+  const accessToken = cookies().get("accessToken")?.value;
+
+  if (!accessToken) {
+    redirect(ROUTE.HOME);
+  }
+
   return (
     <div className="flex h-screen">
       <div className="w-[67px] px-[14px] py-5 border-r border-gray-400 tablet:w-[160px] tablet:px-[13px] pc:w-[300px] pc:px-3">

--- a/src/app/(after-login)/mydashboard/layout.tsx
+++ b/src/app/(after-login)/mydashboard/layout.tsx
@@ -1,6 +1,6 @@
 import { DashboardList } from "@/lib/types";
 import { fetchDashboardList } from "@/lib/apis/dashboardsApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
+import { cookies } from "next/headers";
 import DashboardMenu from "@/components/layout/navbar/DashboardMenu";
 import UserMenu from "@/components/layout/navbar/UserMenu";
 
@@ -11,8 +11,10 @@ export default async function Layout({
 }: {
   children: React.ReactNode;
 }) {
+  const accessToken = cookies().get("accessToken")?.value ?? "";
+
   const { dashboards } = await fetchDashboardList({
-    token: TOKEN_1,
+    token: accessToken,
     page: 1,
     size: PAGE_SIZE,
   });

--- a/src/app/(after-login)/mypage/_components/ProfileSection.tsx
+++ b/src/app/(after-login)/mypage/_components/ProfileSection.tsx
@@ -3,18 +3,18 @@
 import { useEffect, useState } from "react";
 import { UserInfo } from "@/lib/types";
 import { fetchUser } from "@/lib/apis/usersApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
 import Button from "@/components/common/button/Button";
 import ImageInput from "@/components/common/input/ImageInput";
 import Input from "@/components/common/input/Input";
 
 export default function ProfileSection() {
   const [data, setData] = useState<UserInfo | null>(null);
+  const accessToken = localStorage.getItem("accessToken") ?? "";
 
   useEffect(() => {
     const getData = async () => {
       const res = await fetchUser({
-        token: TOKEN_1,
+        token: accessToken,
       });
       setData(res);
     };

--- a/src/app/(after-login)/mypage/layout.tsx
+++ b/src/app/(after-login)/mypage/layout.tsx
@@ -1,6 +1,6 @@
 import { DashboardList } from "@/lib/types";
 import { fetchDashboardList } from "@/lib/apis/dashboardsApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
+import { cookies } from "next/headers";
 import DashboardMenu from "@/components/layout/navbar/DashboardMenu";
 import UserMenu from "@/components/layout/navbar/UserMenu";
 
@@ -11,8 +11,10 @@ export default async function Layout({
 }: {
   children: React.ReactNode;
 }) {
+  const accessToken = cookies().get("accessToken")?.value ?? "";
+
   const { dashboards } = await fetchDashboardList({
-    token: TOKEN_1,
+    token: accessToken,
     page: 1,
     size: PAGE_SIZE,
   });

--- a/src/app/(after-login)/mypage/page.tsx
+++ b/src/app/(after-login)/mypage/page.tsx
@@ -1,8 +1,16 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 import BackButton from "./_components/BackButton";
 import PasswordSection from "./_components/PasswordSection";
 import ProfileSection from "./_components/ProfileSection";
 
 export default function Page() {
+  const accessToken = cookies().get("accessToken")?.value;
+
+  if (!accessToken) {
+    redirect("/");
+  }
+
   return (
     <div className="flex flex-col px-3 py-4">
       <div className="flex flex-col gap-[6px] tablet:gap-[29px]">

--- a/src/app/(after-login)/mypage/page.tsx
+++ b/src/app/(after-login)/mypage/page.tsx
@@ -1,16 +1,8 @@
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import BackButton from "./_components/BackButton";
 import PasswordSection from "./_components/PasswordSection";
 import ProfileSection from "./_components/ProfileSection";
 
 export default function Page() {
-  const accessToken = cookies().get("accessToken")?.value;
-
-  if (!accessToken) {
-    redirect("/");
-  }
-
   return (
     <div className="flex flex-col px-3 py-4">
       <div className="flex flex-col gap-[6px] tablet:gap-[29px]">

--- a/src/app/(before-login)/(with-navbar)/page.tsx
+++ b/src/app/(before-login)/(with-navbar)/page.tsx
@@ -8,7 +8,6 @@ import {
   useIsTablet,
 } from "@/lib/hooks/useCheckViewport";
 import ROUTE from "@/lib/constants/route";
-import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { twMerge } from "tailwind-merge";
 import clsx from "clsx";
@@ -27,20 +26,7 @@ export default function Home() {
   const isMobile = useIsMobile();
   const isTablet = useIsTablet();
   const isPC = useIsPC();
-
-  const [isRedirecting, setIsRedirecting] = useState(true);
   const router = useRouter();
-
-  useEffect(() => {
-    const accessToken = localStorage.getItem("accessToken");
-    if (accessToken) {
-      router.replace(ROUTE.MYDASHBOARD);
-    } else {
-      setIsRedirecting(false);
-    }
-  }, []);
-
-  if (isRedirecting) return;
 
   const pointStyle = twMerge(
     clsx({

--- a/src/app/(before-login)/(with-navbar)/page.tsx
+++ b/src/app/(before-login)/(with-navbar)/page.tsx
@@ -8,6 +8,7 @@ import {
   useIsTablet,
 } from "@/lib/hooks/useCheckViewport";
 import ROUTE from "@/lib/constants/route";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { twMerge } from "tailwind-merge";
 import clsx from "clsx";
@@ -27,7 +28,19 @@ export default function Home() {
   const isTablet = useIsTablet();
   const isPC = useIsPC();
 
+  const [isRedirecting, setIsRedirecting] = useState(true);
   const router = useRouter();
+
+  useEffect(() => {
+    const accessToken = localStorage.getItem("accessToken");
+    if (accessToken) {
+      router.replace(ROUTE.MYDASHBOARD);
+    } else {
+      setIsRedirecting(false);
+    }
+  }, []);
+
+  if (isRedirecting) return;
 
   const pointStyle = twMerge(
     clsx({

--- a/src/app/(before-login)/(without-navbar)/login/page.tsx
+++ b/src/app/(before-login)/(without-navbar)/login/page.tsx
@@ -6,14 +6,12 @@ import { AuthLayout } from "@/app/(before-login)/(without-navbar)/layout";
 import { loginSchema, LoginFormData } from "@/lib/utils/validationSchema";
 import { useAlertStore } from "@/lib/store/useAlertStore";
 import { fetchLogin } from "@/lib/apis/authApi";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
-import ROUTE from "@/lib/constants/route";
 
 export default function Page() {
   const { openAlert } = useAlertStore();
   const [isLoading, setIsLoading] = useState(false);
-  const [isRedirecting, setIsRedirecting] = useState(true);
   const router = useRouter();
 
   const {
@@ -49,17 +47,6 @@ export default function Page() {
       }
     }
   };
-
-  useEffect(() => {
-    const accessToken = localStorage.getItem("accessToken");
-    if (accessToken) {
-      router.replace(ROUTE.MYDASHBOARD);
-    } else {
-      setIsRedirecting(false);
-    }
-  }, []);
-
-  if (isRedirecting) return;
 
   return (
     <AuthLayout

--- a/src/app/(before-login)/(without-navbar)/login/page.tsx
+++ b/src/app/(before-login)/(without-navbar)/login/page.tsx
@@ -6,12 +6,14 @@ import { AuthLayout } from "@/app/(before-login)/(without-navbar)/layout";
 import { loginSchema, LoginFormData } from "@/lib/utils/validationSchema";
 import { useAlertStore } from "@/lib/store/useAlertStore";
 import { fetchLogin } from "@/lib/apis/authApi";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import ROUTE from "@/lib/constants/route";
 
 export default function Page() {
   const { openAlert } = useAlertStore();
   const [isLoading, setIsLoading] = useState(false);
+  const [isRedirecting, setIsRedirecting] = useState(true);
   const router = useRouter();
 
   const {
@@ -29,6 +31,7 @@ export default function Page() {
       const response = await fetchLogin(data);
       setIsLoading(false);
       localStorage.setItem("accessToken", response.accessToken);
+      document.cookie = `accessToken=${response.accessToken}; path=/`;
       openAlert("loginSuccess");
       router.push("/mydashboard");
     } catch (error: unknown) {
@@ -46,6 +49,17 @@ export default function Page() {
       }
     }
   };
+
+  useEffect(() => {
+    const accessToken = localStorage.getItem("accessToken");
+    if (accessToken) {
+      router.replace(ROUTE.MYDASHBOARD);
+    } else {
+      setIsRedirecting(false);
+    }
+  }, []);
+
+  if (isRedirecting) return;
 
   return (
     <AuthLayout

--- a/src/app/(before-login)/(without-navbar)/signup/page.tsx
+++ b/src/app/(before-login)/(without-navbar)/signup/page.tsx
@@ -6,12 +6,14 @@ import { AuthLayout } from "@/app/(before-login)/(without-navbar)/layout";
 import { signupSchema, SignupFormData } from "@/lib/utils/validationSchema";
 import { useAlertStore } from "@/lib/store/useAlertStore";
 import { fetchSignup } from "@/lib/apis/authApi";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import ROUTE from "@/lib/constants/route";
 
 export default function Page() {
   const { openAlert } = useAlertStore();
   const [isLoading, setIsLoading] = useState(false);
+  const [isRedirecting, setIsRedirecting] = useState(true);
   const router = useRouter();
 
   const {
@@ -44,6 +46,17 @@ export default function Page() {
       }
     }
   };
+
+  useEffect(() => {
+    const accessToken = localStorage.getItem("accessToken");
+    if (accessToken) {
+      router.replace(ROUTE.MYDASHBOARD);
+    } else {
+      setIsRedirecting(false);
+    }
+  }, []);
+
+  if (isRedirecting) return;
 
   return (
     <AuthLayout

--- a/src/app/(before-login)/(without-navbar)/signup/page.tsx
+++ b/src/app/(before-login)/(without-navbar)/signup/page.tsx
@@ -6,14 +6,12 @@ import { AuthLayout } from "@/app/(before-login)/(without-navbar)/layout";
 import { signupSchema, SignupFormData } from "@/lib/utils/validationSchema";
 import { useAlertStore } from "@/lib/store/useAlertStore";
 import { fetchSignup } from "@/lib/apis/authApi";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
-import ROUTE from "@/lib/constants/route";
 
 export default function Page() {
   const { openAlert } = useAlertStore();
   const [isLoading, setIsLoading] = useState(false);
-  const [isRedirecting, setIsRedirecting] = useState(true);
   const router = useRouter();
 
   const {
@@ -46,17 +44,6 @@ export default function Page() {
       }
     }
   };
-
-  useEffect(() => {
-    const accessToken = localStorage.getItem("accessToken");
-    if (accessToken) {
-      router.replace(ROUTE.MYDASHBOARD);
-    } else {
-      setIsRedirecting(false);
-    }
-  }, []);
-
-  if (isRedirecting) return;
 
   return (
     <AuthLayout

--- a/src/app/(before-login)/layout.tsx
+++ b/src/app/(before-login)/layout.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from "react";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import ROUTE from "@/lib/constants/route";
+
+export default function Layout({ children }: { children: ReactNode }) {
+  const accessToken = cookies().get("accessToken")?.value;
+
+  if (accessToken) {
+    redirect(ROUTE.MYDASHBOARD);
+  }
+
+  return <div>{children}</div>;
+}

--- a/src/components/common/alert/AlertProvider.tsx
+++ b/src/components/common/alert/AlertProvider.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "next/navigation";
 import { useAlertStore } from "@/lib/store/useAlertStore";
 import { useColumnStore } from "@/lib/store/useColumnStore";
 import { deleteColumn } from "@/lib/apis/columnsApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
 import Alert from "@/components/common/alert/Alert";
 import ROUTE from "@/lib/constants/route";
 
@@ -12,10 +11,11 @@ export default function AlertProvider() {
   const { currentAlert } = useAlertStore();
   const { selectedColumnId } = useColumnStore();
   const router = useRouter();
+  const accessToken = localStorage.getItem("accessToken") ?? "";
 
   const handleDeleteClick = async () => {
     deleteColumn({
-      token: TOKEN_1,
+      token: accessToken,
       columnId: Number(selectedColumnId),
     });
 

--- a/src/components/common/modal/MenuButton.tsx
+++ b/src/components/common/modal/MenuButton.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { deleteCard } from "@/lib/apis/cardsApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
 import { useModalStore } from "@/lib/store/useModalStore";
 import Image from "next/image";
 import MenuButtonIcon from "../../../../public/icon/menu_icon.svg";
@@ -10,6 +9,7 @@ export default function MenuButton() {
   const [isOpen, setIsOpen] = useState(false);
   const { openModal, closeModal } = useModalStore();
   const { selectedTaskId } = useTaskStore();
+  const accessToken = localStorage.getItem("accessToken") ?? "";
 
   const openModifyModal = () => {
     closeModal();
@@ -20,7 +20,7 @@ export default function MenuButton() {
     if (!selectedTaskId) return;
 
     await deleteCard({
-      token: TOKEN_1,
+      token: accessToken,
       cardId: selectedTaskId,
     });
 

--- a/src/components/layout/navbar/UserMenu.tsx
+++ b/src/components/layout/navbar/UserMenu.tsx
@@ -5,24 +5,23 @@ import { UserInfo } from "@/lib/types";
 import { useRouter } from "next/navigation";
 import { useDashboardStore } from "@/lib/store/useDashboardStore";
 import { fetchUser } from "@/lib/apis/usersApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
 import { useIsMobile } from "@/lib/hooks/useCheckViewport";
 import UserIcon from "@/components/common/user-icon/UserIcon";
 import ROUTE from "@/lib/constants/route";
 
 export default function UserMenu() {
   const [data, setData] = useState<UserInfo | null>(null);
-
   const [isOpen, setIsOpen] = useState(false);
   const isMobile = useIsMobile();
   const router = useRouter();
+  const accessToken = localStorage.getItem("accessToken") ?? "";
 
   const setDashboardId = useDashboardStore((state) => state.setDashboardId);
 
   useEffect(() => {
     const getData = async () => {
       const res = await fetchUser({
-        token: TOKEN_1,
+        token: accessToken,
       });
       setData(res);
     };

--- a/src/components/layout/navbar/UserMenu.tsx
+++ b/src/components/layout/navbar/UserMenu.tsx
@@ -41,6 +41,7 @@ export default function UserMenu() {
 
   const handleLogout = () => {
     localStorage.removeItem("accessToken");
+    document.cookie = "accessToken=; path=/; max-age=0";
     router.push(ROUTE.HOME);
   };
 

--- a/src/components/layout/navbar/UserMenu.tsx
+++ b/src/components/layout/navbar/UserMenu.tsx
@@ -40,7 +40,7 @@ export default function UserMenu() {
   };
 
   const handleLogout = () => {
-    alert("로그아웃"); // 로그아웃 API 요청 넣기
+    localStorage.removeItem("accessToken");
     router.push(ROUTE.HOME);
   };
 

--- a/src/components/layout/sidebar/SideMenuList.tsx
+++ b/src/components/layout/sidebar/SideMenuList.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState, useRef } from "react";
 import { useIntersection } from "@/lib/hooks/useIntersection";
 import { DashboardList } from "@/lib/types";
 import { fetchDashboardList } from "@/lib/apis/dashboardsApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
 import SideMenuItem from "./SideMenuItem";
 
 const PAGE_SIZE = 15;
@@ -15,6 +14,7 @@ export default function SideMenuList() {
   const [isLoading, setIsLoading] = useState(false);
   const [isLast, setIsLast] = useState(false);
   const observerRef = useRef<HTMLDivElement | null>(null);
+  const accessToken = localStorage.getItem("accessToken") ?? "";
 
   const handleLoad = async () => {
     if (isLoading || isLast) return;
@@ -22,7 +22,7 @@ export default function SideMenuList() {
 
     try {
       const { dashboards: newDashboards } = await fetchDashboardList({
-        token: TOKEN_1,
+        token: accessToken,
         size: PAGE_SIZE,
         page,
       });

--- a/src/components/modal/add-column/AddColumnModal.tsx
+++ b/src/components/modal/add-column/AddColumnModal.tsx
@@ -3,7 +3,6 @@ import { useRouter } from "next/navigation";
 import { DashboardColumn } from "@/lib/types";
 import { useDashboardStore } from "@/lib/store/useDashboardStore";
 import { fetchColumnList, postColumn } from "@/lib/apis/columnsApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
 import Modal from "@/components/common/modal/Modal";
 import Input from "@/components/common/input/Input";
 
@@ -19,13 +18,14 @@ export default function CreateDashboardModal() {
   const [isFormValid, setIsFormValid] = useState(false);
   const { dashboardId } = useDashboardStore();
   const router = useRouter();
+  const accessToken = localStorage.getItem("accessToken") ?? "";
 
   useEffect(() => {
     if (!dashboardId) return;
 
     const getData = async () => {
       const res = await fetchColumnList({
-        token: TOKEN_1,
+        token: accessToken,
         id: dashboardId,
       });
       setColumnList(res.data);
@@ -53,7 +53,7 @@ export default function CreateDashboardModal() {
     if (!dashboardId) return;
 
     await postColumn({
-      token: TOKEN_1,
+      token: accessToken,
       title: inputValue,
       dashboardId: Number(dashboardId),
     });

--- a/src/components/modal/create-dashboard/CreateDashboardModal.tsx
+++ b/src/components/modal/create-dashboard/CreateDashboardModal.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { postDashboard } from "@/lib/apis/dashboardsApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
 import Modal from "@/components/common/modal/Modal";
 import Input from "@/components/common/input/Input";
 import ColorPalette, {
@@ -13,6 +12,7 @@ export default function CreateDashboardModal() {
   const [selectedColor, setSelectedColor] = useState<ColorCode | "">("");
   const [isFormValid, setIsFormValid] = useState(false);
   const router = useRouter();
+  const accessToken = localStorage.getItem("accessToken") ?? "";
 
   const onColorSelect = (color: ColorCode | "") => {
     setSelectedColor(() => {
@@ -32,7 +32,7 @@ export default function CreateDashboardModal() {
 
   const createDashboard = async () => {
     const res = await postDashboard({
-      token: TOKEN_1,
+      token: accessToken,
       title: dashboardName,
       color: selectedColor,
     });

--- a/src/components/modal/editColumn/EditColumnModal.tsx
+++ b/src/components/modal/editColumn/EditColumnModal.tsx
@@ -4,7 +4,6 @@ import { DashboardColumn } from "@/lib/types";
 import { useDashboardStore } from "@/lib/store/useDashboardStore";
 import { useColumnStore } from "@/lib/store/useColumnStore";
 import { fetchColumnList, putColumn } from "@/lib/apis/columnsApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
 import Modal from "@/components/common/modal/Modal";
 import Input from "@/components/common/input/Input";
 
@@ -21,13 +20,14 @@ export default function CreateDashboardModal() {
   const [isFormValid, setIsFormValid] = useState(false);
   const { dashboardId } = useDashboardStore();
   const router = useRouter();
+  const accessToken = localStorage.getItem("accessToken") ?? "";
 
   useEffect(() => {
     if (!dashboardId) return;
 
     const getData = async () => {
       const res = await fetchColumnList({
-        token: TOKEN_1,
+        token: accessToken,
         id: dashboardId,
       });
       setColumnList(res.data);
@@ -57,7 +57,7 @@ export default function CreateDashboardModal() {
     if (!selectedColumnId) return;
 
     await putColumn({
-      token: TOKEN_1,
+      token: accessToken,
       title: inputValue,
       columnId: Number(selectedColumnId),
     });

--- a/src/components/modal/invite/InviteModal.tsx
+++ b/src/components/modal/invite/InviteModal.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useDashboardStore } from "@/lib/store/useDashboardStore";
 import { postInvitation } from "@/lib/apis/dashboardsApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
 import { isValidEmail } from "@/lib/utils/validationUtils";
 import Modal from "@/components/common/modal/Modal";
 import Input from "@/components/common/input/Input";
@@ -13,6 +12,7 @@ export default function CreateDashboardModal() {
   const [isFormValid, setIsFormValid] = useState(false);
   const { dashboardId } = useDashboardStore();
   const router = useRouter();
+  const accessToken = localStorage.getItem("accessToken") ?? "";
 
   // 이메일 유효성 검사는 나중에 아름님이 하시는 걸로 수정 예정
   useEffect(() => {
@@ -33,7 +33,7 @@ export default function CreateDashboardModal() {
     if (!dashboardId) return;
 
     postInvitation({
-      token: TOKEN_1,
+      token: accessToken,
       id: Number(dashboardId),
       email: inputValue,
     });

--- a/src/components/modal/task-detail/CommentCard.tsx
+++ b/src/components/modal/task-detail/CommentCard.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { Comment } from "@/lib/types";
 import { putComment, deleteComment } from "@/lib/apis/commentsApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
 import { useIsMobile } from "@/lib/hooks/useCheckViewport";
 import { formatDate } from "@/lib/utils/dateUtils";
 import UserIcon from "@/components/common/user-icon/UserIcon";
@@ -24,6 +23,7 @@ export default function CommentCard({
   const [isFormValid, setIsFormValid] = useState(false);
   const isMobile = useIsMobile();
   const date = formatDate(createdAt, true);
+  const accessToken = localStorage.getItem("accessToken") ?? "";
 
   useEffect(() => {
     const trimmedValue = inputValue.trim();
@@ -40,7 +40,7 @@ export default function CommentCard({
 
   const handleEditComment = async () => {
     await putComment({
-      token: TOKEN_1,
+      token: accessToken,
       content: inputValue.trim(),
       commentId: id,
     });
@@ -51,7 +51,7 @@ export default function CommentCard({
 
   const handleDeleteComment = () => {
     deleteComment({
-      token: TOKEN_1,
+      token: accessToken,
       commentId: id,
     });
 

--- a/src/components/modal/task-detail/CommentList.tsx
+++ b/src/components/modal/task-detail/CommentList.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState, useRef } from "react";
 import { useIntersection } from "@/lib/hooks/useIntersection";
 import { Comment } from "@/lib/types";
 import { fetchCommentList } from "@/lib/apis/commentsApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
 import CommentCard from "./CommentCard";
 
 const PAGE_SIZE = 3;
@@ -19,6 +18,7 @@ export default function CommentList({
   const [isLoading, setIsLoading] = useState(false);
   const [isLast, setIsLast] = useState(false);
   const observerRef = useRef<HTMLDivElement | null>(null);
+  const accessToken = localStorage.getItem("accessToken") ?? "";
 
   const handleLoad = async () => {
     if (isLoading || isLast) return;
@@ -27,7 +27,7 @@ export default function CommentList({
     try {
       const { comments: newComments, cursorId: nextCursorId } =
         await fetchCommentList({
-          token: TOKEN_1,
+          token: accessToken,
           size: PAGE_SIZE,
           cursorId,
           cardId: id,

--- a/src/components/modal/task-detail/TaskCommentSection.tsx
+++ b/src/components/modal/task-detail/TaskCommentSection.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { useDashboardStore } from "@/lib/store/useDashboardStore";
 import { postComment } from "@/lib/apis/commentsApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
 import Button from "@/components/common/button/Button";
 import Textarea from "@/components/common/textarea/Textarea";
 import CommentList from "./CommentList";
@@ -17,6 +16,7 @@ export default function TaskCommentSection({
   const [isFormValid, setIsFormValid] = useState(false);
   const [commentListKey, setCommentListKey] = useState(0);
   const { dashboardId } = useDashboardStore();
+  const accessToken = localStorage.getItem("accessToken") ?? "";
 
   useEffect(() => {
     const trimmedValue = inputValue.trim();
@@ -31,7 +31,7 @@ export default function TaskCommentSection({
     if (!dashboardId) return;
 
     await postComment({
-      token: TOKEN_1,
+      token: accessToken,
       content: inputValue.trim(),
       cardId: cardId,
       columnId: columnId,

--- a/src/components/modal/task-detail/TaskDetailModal.tsx
+++ b/src/components/modal/task-detail/TaskDetailModal.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import { TaskCardDetail } from "@/lib/types";
 import { useTaskStore } from "@/lib/store/useTaskStore";
 import { fetchTaskCardDetail } from "@/lib/apis/cardsApi";
-import { TOKEN_1 } from "@/lib/constants/tokens";
 import Modal from "@/components/common/modal/Modal";
 import TaskInfoSection from "./TaskInfoSection";
 import TaskContentSection from "./TaskContentSection";
@@ -12,6 +11,7 @@ export default function TaskDetailModal() {
   const { selectedTaskId } = useTaskStore();
   const [data, setData] = useState<TaskCardDetail | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const accessToken = localStorage.getItem("accessToken") ?? "";
 
   const handleLoad = async () => {
     if (!selectedTaskId) return;
@@ -20,7 +20,7 @@ export default function TaskDetailModal() {
 
     try {
       const res = await fetchTaskCardDetail({
-        token: TOKEN_1,
+        token: accessToken,
         id: selectedTaskId,
       });
       setData(res);

--- a/src/lib/apis/membersApi.ts
+++ b/src/lib/apis/membersApi.ts
@@ -2,21 +2,27 @@ import { BASE_URL } from "@/lib/constants/urls";
 
 export async function fetchDashboardMember({
   token,
+  page,
+  size,
   id,
 }: {
   token: string;
+  page: number;
+  size: number | null;
   id: string;
 }) {
-  const res = await fetch(
-    `${BASE_URL}/members?page=1&size=20&dashboardId=${id}`,
-    {
-      headers: {
-        Accept: "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-      cache: "no-store",
-    }
-  );
+  let query = `page=${page}&dashboardId=${id}`;
+  if (size !== null) {
+    query += `&size=${size}`;
+  }
+
+  const res = await fetch(`${BASE_URL}/members?${query}`, {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    cache: "no-store",
+  });
 
   return res.json();
 }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- "#이슈번호" 형식으로 입력해주세요. -->
#67 

<br/>

## 📝 요약

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
<!--- "어떻게"보다 "무엇"을 "왜" 수정했는지 설명하는 것이 좋습니다. -->
- 로그인 시 localStorage 뿐만 아니라 cookie에도 액세스 토큰 값을 저장하도록 변경(서버 컴포넌트에서는 localStorage에서 토큰 값을 가져올 수 없어서 cookie에서 가져와야 됨)
- 로그아웃 시 localStorage와 cookie에 저장했던 토큰 값 지운 뒤 `/` 페이지로 이동
- 임시 토큰으로 리퀘스트 보냈던 부분들을 실제 localStorage와 cookie에 저장되어 있는 토큰으로 리퀘스트 보내는 것으로 변경
- `fetchDashboardMember` 함수의 리퀘스트 쿼리 변경

<br/>

## 🛠️ PR 유형

<!--- 해당하는 변경 사항에 체크하세요. -->

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>

## 📢 공유 사항

<!--- 차후 작업 시 알아야 할 내용이 있다면 작성해주세요. -->

<br/>

## 📚 참고 자료

<!--- 코드 이해에 도움이 되는 자료 및 설명을 추가해주세요. -->
### `fetchDashboardMember` 함수 사용법
1. 페이지 사이즈 상수 선언
  이 페이지 사이즈만큼 데이터를 한 페이지씩 불러옵니다.
  ```
  const PAGE_SIZE = 4;
  ```
2. 전역 `dashboardId` 값 가져오기(리퀘스트 시 필요)
  ```
  import { useDashboardStore } from "@/lib/store/useDashboardStore";
  ...
  컴포넌트 내에서
  const { dashboardId } = useDashboardStore();
  ```
3. `handleLoad` 같은 함수를 선언한 뒤 그 안에서 `fetchDashboardMember` 함수를 호출
  ```
  const handleLoad = async () => {
  if (!dashboardId) return; // dashboardId가 없는 경우에는 리퀘스트 못 보내도록 이 코드 꼭 필요
  
        const {
        members,
        totalCount,
      } = await fetchDashboardMember({
        token: accessToken, // 위의 accessToken 값 가져오는 방법 참고
        page: page, // 아마 `page` state를 만들어서 그 값을 여기 담아 보내게 될 겁니다.
        size: PAGE_SIZE,
        cursorId,
        columnId: dashboardId, // 전역으로 관리하는 dashboardId 그냥 넣어주시면 됩니다.
      });
  ```
4. useEffect에서 `handleLoad` 함수 실행
  ```
  useEffect(() => {
    handleLoad();
  }, []);
  ```