### PR TITLE
[refactor] #137/데이터 로딩 시 layout shift 방지

### DIFF
--- a/src/app/(after-login)/dashboard/[dashboardid]/edit/_components/DashboardEditSection.tsx
+++ b/src/app/(after-login)/dashboard/[dashboardid]/edit/_components/DashboardEditSection.tsx
@@ -25,6 +25,7 @@ export default function DashboardEditSection({
   const setDashboardId = useDashboardStore((state) => state.setDashboardId);
 
   useEffect(() => {
+    if (loading) return;
     setLoading(true);
 
     try {
@@ -83,7 +84,6 @@ export default function DashboardEditSection({
   };
 
   if (!data) return;
-  if (loading) return <p>Loading...</p>;
 
   return (
     <div className="w-full p-4 rounded-lg bg-white tablet:p-6">
@@ -109,7 +109,7 @@ export default function DashboardEditSection({
             onClick={editDashboard}
             disabled={!isFormValid}
           >
-            {!loading && "변경"}
+            변경
           </Button>
         </div>
       </div>

--- a/src/app/(after-login)/dashboard/[dashboardid]/edit/_components/InvitationSection.tsx
+++ b/src/app/(after-login)/dashboard/[dashboardid]/edit/_components/InvitationSection.tsx
@@ -23,6 +23,7 @@ export default function InvitationSection({
   const totalPage = Math.ceil(totalCount / PAGE_SIZE);
 
   const handleLoad = async () => {
+    if (loading) return;
     setLoading(true);
 
     try {
@@ -56,8 +57,6 @@ export default function InvitationSection({
       setPage((prev) => prev + 1);
     }
   };
-
-  if (loading) return <p>Loading...</p>;
 
   return (
     <div className="flex flex-col gap-[26px] w-full p-4 rounded-lg bg-white tablet:gap-[17px] tablet:p-6">

--- a/src/components/layout/navbar/UserMenu.tsx
+++ b/src/components/layout/navbar/UserMenu.tsx
@@ -22,7 +22,7 @@ export default function UserMenu() {
 
   useEffect(() => {
     const getData = async () => {
-      if (!accessToken) return;
+      if (!accessToken || loading) return;
       setLoading(true);
 
       try {
@@ -40,7 +40,6 @@ export default function UserMenu() {
     getData();
   }, [accessToken]);
 
-  if (loading) return <p>Loading...</p>;
   if (!data) return null;
 
   const { nickname, profileImageUrl } = data;

--- a/src/components/modal/add-column/AddColumnModal.tsx
+++ b/src/components/modal/add-column/AddColumnModal.tsx
@@ -22,7 +22,7 @@ export default function CreateDashboardModal() {
   const accessToken = localStorage.getItem("accessToken") ?? "";
 
   useEffect(() => {
-    if (!dashboardId) return;
+    if (!dashboardId || loading) return;
     setLoading(true);
 
     try {
@@ -77,7 +77,6 @@ export default function CreateDashboardModal() {
   };
 
   if (!dashboardId) return;
-  if (loading) return <p>Loading...</p>;
 
   return (
     <Modal

--- a/src/components/modal/edit-task/AssigneeDropdown.tsx
+++ b/src/components/modal/edit-task/AssigneeDropdown.tsx
@@ -26,6 +26,7 @@ export default function AssigneeDropdown({
 
   useEffect(() => {
     const getData = async () => {
+      if (loading) return;
       setLoading(true);
 
       try {
@@ -45,8 +46,6 @@ export default function AssigneeDropdown({
 
     getData();
   }, []);
-
-  if (loading) return <p>Loading...</p>;
 
   const selected = members.find((member) => member.userId === memberId);
 

--- a/src/components/modal/edit-task/ColumnDropdown.tsx
+++ b/src/components/modal/edit-task/ColumnDropdown.tsx
@@ -22,6 +22,7 @@ export default function ColumnDropdown({
   const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
+    if (loading) return;
     setLoading(true);
 
     try {
@@ -42,7 +43,6 @@ export default function ColumnDropdown({
   }, []);
 
   const selected = columns.find((col) => col.id === columnId);
-  if (loading) return <p>Loading...</p>;
 
   return (
     <div className="relative flex flex-col w-full tablet:min-w-[217px]">

--- a/src/components/modal/editColumn/EditColumnModal.tsx
+++ b/src/components/modal/editColumn/EditColumnModal.tsx
@@ -12,7 +12,7 @@ export interface ColumnListResponse {
   data: DashboardColumn[];
 }
 
-export default function CreateDashboardModal() {
+export default function EditColumnModal() {
   const { selectedColumnId, selectedColumnTitle } = useColumnStore();
   const [columnList, setColumnList] = useState<DashboardColumn[]>([]);
   const [loading, setLoading] = useState(false);
@@ -24,7 +24,7 @@ export default function CreateDashboardModal() {
   const accessToken = localStorage.getItem("accessToken") ?? "";
 
   useEffect(() => {
-    if (!dashboardId) return;
+    if (!dashboardId || loading) return;
     setLoading(true);
 
     try {
@@ -81,7 +81,6 @@ export default function CreateDashboardModal() {
   };
 
   if (!dashboardId) return;
-  if (loading) return <p>Loading...</p>;
 
   return (
     <Modal

--- a/src/components/modal/invite/InviteModal.tsx
+++ b/src/components/modal/invite/InviteModal.tsx
@@ -31,7 +31,7 @@ export default function InviteModal() {
   };
 
   const buttonClick = async () => {
-    if (!dashboardId) return;
+    if (!dashboardId || loading) return;
     setLoading(true);
 
     try {
@@ -58,22 +58,16 @@ export default function InviteModal() {
         disabled: !isFormValid,
       }}
     >
-      {loading ? (
-        <p>Loading...</p>
-      ) : (
-        <div className="tablet:w-[520px]">
-          <Input
-            label="이메일"
-            placeholder="이메일을 입력해 주세요"
-            value={inputValue}
-            onChange={handleChange}
-            error={isInvalidEmail}
-            errorMessage={
-              isInvalidEmail ? "이메일 형식으로 작성해 주세요." : ""
-            }
-          />
-        </div>
-      )}
+      <div className="tablet:w-[520px]">
+        <Input
+          label="이메일"
+          placeholder="이메일을 입력해 주세요"
+          value={inputValue}
+          onChange={handleChange}
+          error={isInvalidEmail}
+          errorMessage={isInvalidEmail ? "이메일 형식으로 작성해 주세요." : ""}
+        />
+      </div>
     </Modal>
   );
 }

--- a/src/components/modal/task-detail/TaskCommentSection.tsx
+++ b/src/components/modal/task-detail/TaskCommentSection.tsx
@@ -29,7 +29,7 @@ export default function TaskCommentSection({
   };
 
   const buttonClick = async () => {
-    if (!dashboardId) return;
+    if (!dashboardId || loading) return;
     setLoading(true);
 
     try {
@@ -51,7 +51,6 @@ export default function TaskCommentSection({
   };
 
   if (!dashboardId) return;
-  if (loading) return <p>Loading...</p>;
 
   return (
     <div className="flex flex-col gap-4 w-[290px] tablet:gap-6 tablet:w-[420px] pc:w-[445px]">

--- a/src/components/modal/task-detail/TaskDetailModal.tsx
+++ b/src/components/modal/task-detail/TaskDetailModal.tsx
@@ -14,8 +14,7 @@ export default function TaskDetailModal() {
   const accessToken = localStorage.getItem("accessToken") ?? "";
 
   const handleLoad = async () => {
-    if (!selectedTaskId) return;
-    if (isLoading) return;
+    if (!selectedTaskId || isLoading) return;
     setIsLoading(true);
 
     try {


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- "#이슈번호" 형식으로 입력해주세요. -->
#137 

<br/>

## 📝 요약

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
<!--- "어떻게"보다 "무엇"을 "왜" 수정했는지 설명하는 것이 좋습니다. -->
원래는 loading 상태일 때 `<p>Loading...</p>`를 리턴해서 로딩 상태를 보여줬는데, 이 방식을 사용하면 데이터가 로드된 후 레이아웃이 밀리는 layout shift가 발생했다.
그래서 렌더링 반환 대신, 데이터 패칭 함수 내부에서 `return;`으로 조기 종료하는 방식으로 변경했다.
이를 통해 UI 구조를 유지한 채 로딩 처리만 할 수 있어서 시각적으로 더 안정적이게 되었다.

<br/>

## 🛠️ PR 유형

<!--- 해당하는 변경 사항에 체크하세요. -->

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제